### PR TITLE
Exclude source artifacts from npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
 src
+.babelrc
+.eslintrc
+.travis.yml
+Makefile

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-core": "^5.6.15",
-    "babel-eslint": "^3.1.20",
+    "babel-eslint": "^4.1.8",
     "chai": "^3.0.0",
     "eslint": "^0.24.0",
     "eslint-config-airbnb": "0.0.6",


### PR DESCRIPTION
Fixes #2.

These files don't need to be included in the published package on npm, so they should be `npmignore`d.  In particular, the extraneous `.babelrc` is causing problems with projects using Babel 6 (including all React Native projects with the latest version of `react-native`).